### PR TITLE
Fix code scanning alert no. 4: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -82,7 +82,7 @@ module GoogleDrive
         request_options = nil
     )
       if json_key_path_or_io.is_a?(String)
-        open(json_key_path_or_io) do |f|
+        File.open(json_key_path_or_io) do |f|
           from_service_account_key(f, scope, client_options, request_options)
         end
       else


### PR DESCRIPTION
Fixes [https://github.com/tadwhitaker/google-drive-ruby/security/code-scanning/4](https://github.com/tadwhitaker/google-drive-ruby/security/code-scanning/4)

To fix the problem, we should replace the use of `Kernel.open` with `File.open`. This change will prevent the potential security vulnerability associated with executing arbitrary code. Specifically, we need to modify the `from_service_account_key` method in the `lib/google_drive/session.rb` file to use `File.open` instead of `open`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
