### PR TITLE
Fix code scanning alert no. 3: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -124,7 +124,7 @@ module GoogleDrive
     # Exports the worksheet to +path+ in CSV format.
     def export_as_file(path)
       data = export_as_string
-      open(path, 'wb') { |f| f.write(data) }
+      File.open(path, 'wb') { |f| f.write(data) }
     end
 
     # ID of the worksheet.


### PR DESCRIPTION
Fixes [https://github.com/tadwhitaker/google-drive-ruby/security/code-scanning/3](https://github.com/tadwhitaker/google-drive-ruby/security/code-scanning/3)

To fix the problem, we should replace the use of `Kernel.open` with `File.open`. This change will prevent the potential security risk associated with executing shell commands through `Kernel.open`. The functionality of the code will remain the same, as `File.open` can be used in the same way to open a file for writing.

We need to modify the `export_as_file` method in the `lib/google_drive/worksheet.rb` file. Specifically, we will replace the `open` call on line 127 with `File.open`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
