### PR TITLE
Fix code scanning alert no. 2: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/lib/google_drive/file.rb
+++ b/lib/google_drive/file.rb
@@ -176,7 +176,7 @@ module GoogleDrive
     def update_from_file(path, params = {})
       # Somehow it doesn't work if I specify the file name directly as
       # upload_source.
-      open(path, 'rb') do |f|
+      File.open(path, 'rb') do |f|
         update_from_io(f, params)
       end
       nil


### PR DESCRIPTION
Fixes [https://github.com/tadwhitaker/google-drive-ruby/security/code-scanning/2](https://github.com/tadwhitaker/google-drive-ruby/security/code-scanning/2)

To fix the problem, we should replace the call to `Kernel.open` with `File.open`, which does not have the same vulnerability. This change will ensure that the file is opened safely without the risk of executing arbitrary code. The functionality of the code will remain the same, as `File.open` can be used in the same way as `Kernel.open` for reading files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
