### PR TITLE
Fix code scanning alert no. 1: Dependency download using unencrypted communication channel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gemspec name: 'google_drive'
 gem 'highline', '>= 1.5.1', group: :test


### PR DESCRIPTION
Fixes [https://github.com/tadwhitaker/google-drive-ruby/security/code-scanning/1](https://github.com/tadwhitaker/google-drive-ruby/security/code-scanning/1)

To fix the problem, we need to change the protocol used in the source URL from HTTP to HTTPS. This ensures that the communication channel is encrypted, preventing potential MITM attacks. The change is straightforward and involves modifying the URL in the `Gemfile`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
